### PR TITLE
Phone: Sprint MWI Quirk: Phantom message wait indicator workaround (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2897,6 +2897,12 @@ public final class Settings {
         public static final String BATTERY_LIGHT_FULL_COLOR = "battery_light_full_color";
 
         /**
+         * Sprint MWI Quirk: Show message wait indicator notifications
+         * @hide
+         */
+        public static final String ENABLE_MWI_NOTIFICATION = "enable_mwi_notification";
+
+        /**
          * Show pointer location on screen?
          * 0 = no
          * 1 = yes


### PR DESCRIPTION
Settings > Message wait indicator

Rebased on Lollipop

For change: http://review.cyanogenmod.org/#/c/79693/

Change-Id: Ic3627c75ff98d3a690658b3cb0ece7f6da6c4869